### PR TITLE
大商所夜盘TICK日期取本地日期

### DIFF
--- a/vnpy/trader/gateway/ctpGateway/ctpGateway.py
+++ b/vnpy/trader/gateway/ctpGateway/ctpGateway.py
@@ -390,16 +390,19 @@ class CtpMdApi(MdApi):
         if tick.exchange is EXCHANGE_DCE:
             newTime = datetime.strptime(tick.time, '%H:%M:%S.%f').time()    # 最新tick时间戳
             
+            """
             # 如果新tick的时间小于夜盘分隔，且上一个tick的时间大于夜盘分隔，则意味着越过了12点
             if (self.tickTime and 
                 newTime < NIGHT_TRADING and
                 self.tickTime > NIGHT_TRADING):
                 self.tradingDt += timedelta(1)                          # 日期加1
                 self.tradingDate = self.tradingDt.strftime('%Y%m%d')    # 生成新的日期字符串
-                
-            tick.date = self.tradingDate    # 使用本地维护的日期
+            """
+
+            #夜盘时间用本地日期
+            if newTime > NIGHT_TRADING:
+                tick.date = datetime.now().strftime('%Y%m%d')    # 使用本地维护的日期
             
-            self.tickTime = newTime         # 更新上一个tick时间
         
         self.gateway.onTick(tick)
         


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 取消原凌晨跨夜判断（导致多合约监听多次累加TICK日期问题），夜盘直接取本地日期（大商所夜盘目前不再跨夜）
2. 
3.

## 相关的Issue号（如有）

Close #